### PR TITLE
feat: implemented infinite scroll - rendering only 10 transactions initially

### DIFF
--- a/src/stores/transactions.ts
+++ b/src/stores/transactions.ts
@@ -1,10 +1,24 @@
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import { defineStore } from 'pinia';
 
 import type { Transaction } from '@/types/transaction.types';
 
 export const useTransactionStore = defineStore('transactions', () => {
   const transactions = ref<Array<Transaction>>([]);
+
+  const pageNo = ref(1);
+  const transactionsPerPage = ref(10);
+
+  const visibleTransactions = computed(() => {
+    return transactions.value.slice(
+      0,
+      pageNo.value * transactionsPerPage.value
+    );
+  });
+
+  function showMoreTransactions() {
+    pageNo.value = pageNo.value + 1;
+  }
 
   function getTransactions(fromDate: string, toDate: string) {
     const fromDateParsed = new Date(fromDate);
@@ -29,7 +43,7 @@ export const useTransactionStore = defineStore('transactions', () => {
       transactions.value = newTransactions;
       return;
     }
-    transactions.value.push(...newTransactions);
+    transactions.value.unshift(...newTransactions);
     localStorage.setItem('transactions', JSON.stringify(transactions.value));
   }
 
@@ -41,5 +55,12 @@ export const useTransactionStore = defineStore('transactions', () => {
     localStorage.setItem('transactions', JSON.stringify(transactions.value));
   }
 
-  return { transactions, addTransactions, deleteTransaction, getTransactions };
+  return {
+    transactions,
+    addTransactions,
+    deleteTransaction,
+    getTransactions,
+    visibleTransactions,
+    showMoreTransactions,
+  };
 });

--- a/src/transactionsController.ts
+++ b/src/transactionsController.ts
@@ -10,7 +10,8 @@ export async function getAllTransactions() {
   try {
     let { data: transactions, error } = await supabase
       .from('transactions')
-      .select('*');
+      .select('*')
+      .order('created_at', { ascending: false });
     return transactions;
   } catch (_) {
     console.log('Error in getting transactions');

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -21,6 +21,7 @@ import {
   saveNewTransactionInDB,
   deleteTransactionFromDB,
 } from '@/transactionsController';
+import { useInfiniteScroll } from '@vueuse/core';
 
 const newTransaction = reactive<Transaction>({
   type: 'Debited',
@@ -33,7 +34,7 @@ const newTransaction = reactive<Transaction>({
 
 const transactionStore = useTransactionStore();
 
-const transactions = computed(() => transactionStore.transactions);
+const transactions = computed(() => transactionStore.visibleTransactions);
 
 function clearTransaction() {
   newTransaction.type = 'Debited';
@@ -179,6 +180,16 @@ async function loadFromSupabese() {
   );
 }
 
+const transactionsWrapper = ref<HTMLElement | null>(null);
+
+useInfiniteScroll(
+  transactionsWrapper,
+  () => {
+    transactionStore.showMoreTransactions();
+  },
+  { distance: 10 }
+);
+
 onMounted(() => {
   loadFromSupabese();
 });
@@ -239,7 +250,7 @@ onMounted(() => {
       <div class="transaction-divider">
         <span class="text">Transactions</span>
       </div>
-      <div class="transactions-wrapper">
+      <div ref="transactionsWrapper" class="transactions-wrapper">
         <TransactionCard
           v-for="(transactionDetail, transactionIdx) of transactions"
           :key="`transaction-${transactionIdx}`"


### PR DESCRIPTION
## Feature: Infinite Scroll

Initially rendering 10 transactions only onto the dashboard, when the user reaches the bottom of the parent element, we render more transactions onto the UI.

### Minor changes

Fetching the transactions in descending order as per created_at column.